### PR TITLE
Add GitHub Action for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build
+          branch: gh-pages
+          clean: true
+          cname: ben.kallaus.io

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,4 @@ jobs:
           folder: build
           branch: gh-pages
           clean: true
-          cname: ben.kallaus.io
+          cname: ben.kallaus.me


### PR DESCRIPTION
Added a GitHub Action to automatically deploy the site to GitHub Pages on push to the main branch. The workflow builds the project and pushes the `build` folder to the `gh-pages` branch, maintaining the custom domain configuration.

---
*PR created automatically by Jules for task [4156858146526588543](https://jules.google.com/task/4156858146526588543) started by @bkallaus*