### PR TITLE
Remove email link from portfolio

### DIFF
--- a/public/portfolio_shared_data.json
+++ b/public/portfolio_shared_data.json
@@ -4,11 +4,6 @@
       "titles": [ "Full Stack Developer", "Senior Software Engineer", "Mobile App Developer" ],
       "social": [
         {
-          "name": "email",
-          "url": "mailto:benkallaus@gmail.com",
-          "class": "fa fa-envelope"
-        },
-        {
           "name": "github",
           "url": "https://github.com/benkallaus",
           "class": "fab fa-github"


### PR DESCRIPTION
Removed the email link from the social media links in the `public/portfolio_shared_data.json` file. This change ensures that only the GitHub and LinkedIn profiles are displayed in the About section of the portfolio. Verification was done using a Playwright script and visual inspection of the screenshot.

---
*PR created automatically by Jules for task [15030559838295377836](https://jules.google.com/task/15030559838295377836) started by @bkallaus*