### PR TITLE
Polish Experience section with timeline layout

### DIFF
--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Experience as ExperienceType, ResumeBasicInfo } from "../types";
+import { motion } from "framer-motion";
 
 type ExperienceProps = {
   resumeExperience: ExperienceType[];
@@ -11,31 +12,71 @@ const Experience: React.FC<ExperienceProps> = ({ resumeExperience, resumeBasicIn
     return null;
   }
 
-  const experience = resumeExperience.map((work) => {
-    return (
-      <div key={work.title} className="mb-8 p-6 border border-gray-200 rounded-lg shadow-sm bg-white hover:shadow-md transition-shadow">
-        <div className="flex flex-col md:flex-row justify-between items-start mb-4">
-          <div>
-            <h3 className="text-xl font-bold text-gray-800">{work.title}</h3>
-            <h4 className="text-lg text-primary font-medium">{work.company}</h4>
-          </div>
-          <span className="text-sm text-gray-500 bg-gray-100 px-3 py-1 rounded-full mt-2 md:mt-0">{work.years}</span>
-        </div>
-
-        <div className="flex flex-wrap gap-2 mt-4">
-          {work.technologies && work.technologies.map((tech, i) => (
-            <span key={i} className="inline-block bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-0.5 rounded">{tech}</span>
-          ))}
-        </div>
-      </div>
-    );
-  });
-
   return (
-    <section id="experience" className="py-16 container mx-auto px-4">
-      <h1 className="text-4xl font-bold text-center mb-12 text-gray-900">Experience</h1>
-      <div className="max-w-4xl mx-auto space-y-8">
-        {experience}
+    <section id="experience" className="py-20 bg-gray-50 overflow-hidden">
+      <div className="container mx-auto px-4">
+        <h1 className="text-4xl font-bold text-center mb-16 text-gray-900">Experience</h1>
+
+        <div className="relative max-w-5xl mx-auto">
+          {/* Vertical Timeline Line */}
+          <div className="absolute left-4 md:left-1/2 top-0 bottom-0 w-1 bg-gray-200 transform md:-translate-x-1/2 hidden md:block rounded-full"></div>
+
+          <div className="space-y-12">
+            {resumeExperience.map((work, index) => {
+              const isEven = index % 2 === 0;
+
+              return (
+                <motion.div
+                  key={work.title + work.company}
+                  initial={{ opacity: 0, y: 50 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true, margin: "-100px" }}
+                  transition={{ duration: 0.5, delay: index * 0.1 }}
+                  className={`relative flex flex-col md:flex-row items-center ${isEven ? 'md:flex-row-reverse' : ''}`}
+                >
+                  {/* Timeline Dot */}
+                  <div className="absolute left-4 md:left-1/2 w-8 h-8 bg-blue-500 rounded-full border-4 border-white shadow-md transform -translate-x-1/2 flex items-center justify-center z-10 hidden md:flex">
+                    <div className="w-2 h-2 bg-white rounded-full"></div>
+                  </div>
+
+                  {/* Empty space for alternating layout on desktop */}
+                  <div className="hidden md:block md:w-1/2 px-8"></div>
+
+                  {/* Content Card */}
+                  <div className="w-full md:w-1/2 px-4 md:px-8">
+                    <div className="bg-white p-6 rounded-xl shadow-lg border border-gray-100 hover:shadow-xl transition-shadow relative">
+
+                      {/* Arrow pointer for desktop */}
+                      <div className={`hidden md:block absolute top-6 w-4 h-4 bg-white border-gray-100 transform rotate-45 ${isEven ? 'left-full -ml-2 border-r border-t' : 'right-full -mr-2 border-l border-b'}`}></div>
+
+                      <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-4 gap-2">
+                        <div>
+                          <h3 className="text-xl font-bold text-gray-900">{work.title}</h3>
+                          <h4 className="text-lg text-blue-600 font-medium">{work.company}</h4>
+                        </div>
+                        <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800 whitespace-nowrap">
+                          {work.years}
+                        </span>
+                      </div>
+
+                      {/* Technologies */}
+                      <div className="flex flex-wrap gap-2 mt-6 pt-4 border-t border-gray-100">
+                        {work.technologies && work.technologies.map((tech, i) => (
+                          <span
+                            key={i}
+                            className="inline-block bg-blue-50 text-blue-700 text-xs font-semibold px-2.5 py-1 rounded-md border border-blue-100"
+                          >
+                            {tech}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/vite_output.log
+++ b/vite_output.log
@@ -1,0 +1,10 @@
+
+> bkallaus-portfolio@0.1.0 dev
+> vite
+
+
+  VITE v7.3.1  ready in 528 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+1:26:14 AM [vite] (client) hmr update /src/components/Experience.tsx, /src/index.css


### PR DESCRIPTION
This PR polishes the Experience section by implementing a vertical timeline UI.

Key changes:
- Redesigned the experience list into an alternating timeline for desktop, falling back to a stacked column for mobile.
- Integrated `framer-motion` to animate the experience cards as they scroll into view.
- Enhanced the visual appearance of the cards with better shadows, rounded corners, and styled technology tags.
- Added directional arrows to the cards pointing to the central timeline on desktop.

---
*PR created automatically by Jules for task [6813831001712463557](https://jules.google.com/task/6813831001712463557) started by @bkallaus*